### PR TITLE
fix: Create logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
-Logs/
+Logs/*
+!Logs/keep


### PR DESCRIPTION
Currently the Logs directory is not present in this repository - this results in Docker trying to create the Logs directory as the root user, causing permission issues when trying to run the headless.